### PR TITLE
fix: unassoc user without deleting org, persist change to local state…

### DIFF
--- a/client/components/AllOrgs.js
+++ b/client/components/AllOrgs.js
@@ -1,12 +1,11 @@
 import React, {useState, useContext, useEffect} from 'react'
-import axios from 'axios'
 import {Link} from 'react-router-dom'
 import {AuthContext} from '../context/authContext'
 import {CgOrganisation} from 'react-icons/cg'
 import {IconContext} from 'react-icons'
 import AddOrgDropdown from './AddOrgDropdown'
 import styles from './css/AllOrgs.module.css'
-import {deleteOrganizationDB, fetchUserOrgs} from '../context/axiosService'
+import {removeUserFromOrgDB, fetchUserOrgs} from '../context/axiosService'
 
 const AllOrgs = () => {
   // grab user from auth context
@@ -32,8 +31,7 @@ const AllOrgs = () => {
   const deleteOrganization = async (e, org) => {
     e.preventDefault()
     try {
-      await deleteOrganizationDB(org)
-      console.log('this is deletedOrg', org)
+      await removeUserFromOrgDB(org.id, user.id)
       setOrganizations(organizations.filter((currOrg) => currOrg.id !== org.id))
     } catch (err) {
       console.error(err)

--- a/client/context/axiosService.js
+++ b/client/context/axiosService.js
@@ -61,6 +61,17 @@ export const addUserToOrgDB = async (orgId, userId) => {
   }
 }
 
+export const removeUserFromOrgDB = async (orgId, userId) => {
+  try {
+    const {data} = await axios.delete(
+      `/api/organizations/${orgId}/users/${userId}`
+    )
+    return data
+  } catch (err) {
+    console.error(err)
+  }
+}
+
 export const fetchAllOrganizations = async () => {
   try {
     const {data} = await axios.get('/api/organizations')

--- a/server/api/users.js
+++ b/server/api/users.js
@@ -7,7 +7,13 @@ const {
   UserOrganization,
 } = require('../db/models')
 const {checkUser, checkAdmin} = require('./helper/gatekeeper')
-const {resNaN, resDbNotFound, resAssoc, resDeleted} = require('./helper/helper')
+const {
+  resNaN,
+  resDbNotFound,
+  resAssoc,
+  resUnassoc,
+  resDeleted,
+} = require('./helper/helper')
 const {STR_USERS, STR_USER, STR_ORGANIZATION} = require('./helper/strings')
 module.exports = router
 


### PR DESCRIPTION
this PR fixes remove user from org route in AllOrgs
rather than delete the org
hit the DELETE /api/organizations/orgId/users/userId route
to unassociate user, persist to local state/db, and keep org intact