### PR TITLE
fix: misspelling in drag setter, taskContext.js

### DIFF
--- a/client/context/taskContext.js
+++ b/client/context/taskContext.js
@@ -9,7 +9,7 @@ export default function TaskProvider({children}) {
   // opening on EVERY task in a column
   const [dropDownTargetId, setDropDownTargetId] = useState(0)
   const [isTaskDropDownVisible, setTaskDropDownVisible] = useState(false)
-  const [dragDisabled, setdragDisabled] = useState(false)
+  const [dragDisabled, setDragDisabled] = useState(false)
 
   const providerValue = {
     dropDownTargetId,
@@ -17,7 +17,7 @@ export default function TaskProvider({children}) {
     isTaskDropDownVisible,
     setTaskDropDownVisible,
     dragDisabled,
-    setdragDisabled,
+    setDragDisabled,
   }
 
   return (


### PR DESCRIPTION
this PR fixes a spelling error in the setter function for drag