### PR TITLE
feat: toast note popup upon signup error

### DIFF
--- a/client/components/Signup.js
+++ b/client/components/Signup.js
@@ -2,6 +2,7 @@ import React, {useState, useContext} from 'react'
 import {AuthContext} from '../context/authContext'
 import axios from 'axios'
 import history from '../history'
+import {notify} from './helper/toast'
 import styles from './css/Signup.module.css'
 
 const Signup = () => {
@@ -31,7 +32,7 @@ const Signup = () => {
         password,
       })
     } catch (err) {
-      console.error(err)
+      notify(`${err}`, 'error')
     }
 
     // pull user out of response, add local set on AuthContext


### PR DESCRIPTION
- Toast note appears now when there is an error upon user signup (e.g. same name/email as a registered user)